### PR TITLE
Merge latest strings from activity-stream changeset 76ed986443f9f4b5c42266dead8442443987b7e3

### DIFF
--- a/l10n/templates/strings.properties
+++ b/l10n/templates/strings.properties
@@ -110,7 +110,27 @@ time_label_minute={number}m
 time_label_hour={number}h
 time_label_day={number}d
 
-# LOCALIZATION NOTE (settings_pane_*): This is shown in the Settings Pane sidebar.
+# LOCALIZATION NOTE (prefs_*, settings_*): These are shown in about:preferences
+# for a "Firefox Home" section. "Firefox" should be treated as a brand and kept
+# in English, while "Home" should be localized matching the about:preferences
+# sidebar mozilla-central string for the panel that has preferences related to
+# what is shown for the homepage, new windows, and new tabs.
+prefs_home_header=Firefox Home Content
+prefs_home_description=Choose what content you want on your Firefox Home screen.
+prefs_restore_defaults_button=Restore Defaults
+# LOCALIZATION NOTE (prefs_section_rows_option): This is a semi-colon list of
+# plural forms used in a drop down of multiple row options (1 row, 2 rows).
+# See: http://developer.mozilla.org/en/docs/Localization_and_Plurals
+prefs_section_rows_option={num} row;{num} rows
+prefs_search_header=Web Search
+prefs_topsites_description=The sites you visit most
+prefs_topstories_description=High-quality content you might otherwise miss
+# LOCALIZATION NOTE (prefs_topstories_show_sponsored_label): {provider} is
+# replaced by the name of the content provider for this section, e.g., "Pocket"
+prefs_topstories_show_sponsored_label={provider} Sponsored Stories
+prefs_topstories_sponsored_learn_more=Learn more
+prefs_highlights_description=A selection of sites that you’ve saved or visited
+prefs_snippets_description=Updates from Mozilla and Firefox
 settings_pane_button_label=Customize your New Tab page
 settings_pane_header=New Tab Preferences
 settings_pane_body2=Choose what you see on this page.
@@ -155,11 +175,16 @@ topsites_form_edit_header=Edit Top Site
 topsites_form_title_label=Title
 topsites_form_title_placeholder=Enter a title
 topsites_form_url_label=URL
+topsites_form_image_url_label=Custom Image URL
 topsites_form_url_placeholder=Type or paste a URL
+topsites_form_use_image_link=Use a custom image…
+# LOCALIZATION NOTE (topsites_form_*_button): These are verbs/actions.
+topsites_form_preview_button=Preview
 topsites_form_add_button=Add
 topsites_form_save_button=Save
 topsites_form_cancel_button=Cancel
 topsites_form_url_validation=Valid URL required
+topsites_form_image_validation=Image failed to load. Try a different URL.
 
 # LOCALIZATION NOTE (pocket_read_more): This is shown at the bottom of the
 # trending stories section and precedes a list of links to popular topics.


### PR DESCRIPTION
This export includes strings for the new Firefox Home Preferences panel as well as for top sites image editing.

about:preferences https://github.com/mozilla/activity-stream/pull/4015
![screen shot 2018-03-01 at 2 59 23 pm](https://user-images.githubusercontent.com/438537/36879336-12e36c8c-1d78-11e8-8faf-d1921e747210.png)

custom image https://github.com/mozilla/activity-stream/pull/3891
![screen shot 2018-03-05 at 5 15 37 pm](https://user-images.githubusercontent.com/438537/37008860-ffb8f2c0-2098-11e8-835b-e6c23cf902ff.png)
